### PR TITLE
fix: remove glog dependency

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -158,13 +158,12 @@ linters-settings:
     # A list of packages for the list type specified.
     # Default: []
     packages:
-      - github.com/sirupsen/logrus
+      - log
 
     # A list of packages for the list type specified.
     # Specify an error message to output when a denied package is used.
     # Default: []
     packages-with-error-message:
-      - github.com/sirupsen/logrus: 'logging is allowed only by logutils.Log'
 
     # Create additional guards that follow the same configuration pattern.
     # Results from all guards are aggregated together.
@@ -199,16 +198,9 @@ linters-settings:
     # Default: false
     check-blank: true
 
-    # DEPRECATED comma-separated list of pairs of the form pkg:regex
-    #
-    # the regex is used to ignore names within pkg. (default "fmt:.*").
-    # see https://github.com/kisielk/errcheck#the-deprecated-method for details
-    ignore: fmt:.*,io/ioutil:^Read.*
-
     # List of functions to exclude from checking, where each entry is a single function to exclude.
     # See https://github.com/kisielk/errcheck#excluding-functions for details.
     exclude-functions:
-      - io/ioutil.ReadFile
       - io.Copy(*bytes.Buffer)
       - io.Copy(os.Stdout)
 
@@ -731,6 +723,8 @@ linters-settings:
     no-extra-aliases: true
     # List of aliases
     alias:
+      - pkg: log
+        alias:
 
 
   ireturn:
@@ -943,7 +937,7 @@ linters-settings:
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#deep-exit
       - name: deep-exit
         severity: warning
-        disabled: false
+        disabled: true # TODO: make false?
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#defer
       - name: defer
         severity: warning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project will adhere to [Semantic Versioning](http://semver.org/spec/v2.
 This release is adopted fork of the https://github.com/dgraph-io/ristretto. Only added is CI actions, code formatting, field alignment fix on structures.
 
 ### Changed
+  - removed glog dependency
 
 ### Added
   - GitHub Actions for build, lint, release, CodeQL

--- a/contrib/memtest/main.go
+++ b/contrib/memtest/main.go
@@ -21,6 +21,7 @@ import "C"
 
 import (
 	"fmt"
+	"log"
 	"math/rand"
 	"net/http"
 	_ "net/http/pprof"
@@ -34,7 +35,6 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/etecs-ru/ristretto/z"
-	"github.com/golang/glog"
 )
 
 type S struct {
@@ -71,7 +71,7 @@ func newS(sz int) *S {
 	s.val = Calloc(sz)
 	copy(s.val, fill)
 	if s.next != nil {
-		glog.Fatalf("news.next must be nil: %p", s.next)
+		log.Fatalf("news.next must be nil: %p", s.next)
 	}
 	return s
 }
@@ -91,7 +91,7 @@ func (s *S) allocateNext(sz int) {
 
 func (s *S) deallocNext() {
 	if s.next == nil {
-		glog.Fatal("next should not be nil")
+		log.Fatal("next should not be nil")
 	}
 	next := s.next
 	s.next = next.next
@@ -165,13 +165,13 @@ func main() {
 	}()
 	go func() {
 		if err := http.ListenAndServe("0.0.0.0:8080", nil); err != nil {
-			glog.Fatalf("Error: %v", err)
+			log.Fatalf("Error: %v", err)
 		}
 	}()
 
 	viaLL()
 	if left := NumAllocBytes(); left != 0 {
-		glog.Fatalf("Unable to deallocate all memory: %v\n", left)
+		log.Fatalf("Unable to deallocate all memory: %v\n", left)
 	}
 	runtime.GC()
 	fmt.Println("Done. Reduced to zero memory usage.")

--- a/contrib/memtest/nojemalloc.go
+++ b/contrib/memtest/nojemalloc.go
@@ -7,11 +7,10 @@ package main
 import "C"
 
 import (
+	"log"
 	"reflect"
 	"sync/atomic"
 	"unsafe"
-
-	"github.com/golang/glog"
 )
 
 func Calloc(size int) []byte {
@@ -44,5 +43,5 @@ func NumAllocBytes() int64 { return atomic.LoadInt64(&numbytes) }
 func check() {}
 
 func init() {
-	glog.Infof("USING CALLOC")
+	log.Println("USING CALLOC")
 }

--- a/contrib/memtest/withjemalloc.go
+++ b/contrib/memtest/withjemalloc.go
@@ -1,11 +1,11 @@
 //go:build jemalloc
-// +build jemalloc
 
 package main
 
 import (
+	"log"
+
 	"github.com/etecs-ru/ristretto/z"
-	"github.com/golang/glog"
 )
 
 func Calloc(size int) []byte { return z.Calloc(size, "memtest") }
@@ -14,7 +14,7 @@ func NumAllocBytes() int64   { return z.NumAllocBytes() }
 
 func check() {
 	if buf := z.CallocNoRef(1, "memtest"); len(buf) == 0 {
-		glog.Fatalf("Not using manual memory management. Compile with jemalloc.")
+		log.Fatalf("Not using manual memory management. Compile with jemalloc.")
 	} else {
 		z.Free(buf)
 	}
@@ -23,5 +23,5 @@ func check() {
 }
 
 func init() {
-	glog.Infof("USING JEMALLOC")
+	log.Println("USING JEMALLOC")
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.1
 	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2
 	github.com/dustin/go-humanize v1.0.0
-	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,6 @@ github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczC
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
-github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/z/bbloom.go
+++ b/z/bbloom.go
@@ -23,10 +23,9 @@ package z
 import (
 	"bytes"
 	"encoding/json"
+	"log"
 	"math"
 	"unsafe"
-
-	"github.com/golang/glog"
 )
 
 // helper
@@ -60,7 +59,7 @@ func NewBloomFilter(params ...float64) (bloomfilter *Bloom) {
 			entries, locs = uint64(params[0]), uint64(params[1])
 		}
 	} else {
-		glog.Fatal("usage: New(float64(number_of_entries), float64(number_of_hashlocations))" +
+		log.Fatal("usage: New(float64(number_of_entries), float64(number_of_hashlocations))" +
 			" i.e. New(float64(1000), float64(3)) or New(float64(number_of_entries)," +
 			" float64(number_of_hashlocations)) i.e. New(float64(1000), float64(0.03))")
 	}
@@ -205,7 +204,7 @@ func (bl Bloom) JSONMarshal() []byte {
 	}
 	data, err := json.Marshal(bloomImEx)
 	if err != nil {
-		glog.Fatal("json.Marshal failed: ", err)
+		log.Fatal("json.Marshal failed: ", err)
 	}
 	return data
 }

--- a/z/buffer.go
+++ b/z/buffer.go
@@ -19,11 +19,11 @@ package z
 import (
 	"encoding/binary"
 	"fmt"
+	"log"
 	"os"
 	"sort"
 	"sync/atomic"
 
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
 )
 
@@ -348,13 +348,13 @@ func (s *sortHelper) sortSmall(start, end int) {
 
 func assert(b bool) {
 	if !b {
-		glog.Fatalf("%+v", errors.Errorf("Assertion failure"))
+		log.Fatal("Assertion failure")
 	}
 }
 
 func check(err error) {
 	if err != nil {
-		glog.Fatalf("%+v", err)
+		log.Fatal(err.Error())
 	}
 }
 

--- a/z/flags.go
+++ b/z/flags.go
@@ -2,6 +2,7 @@ package z
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -10,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
 )
 
@@ -109,7 +109,7 @@ type SuperFlag struct {
 func NewSuperFlag(flag string) *SuperFlag {
 	sf, err := newSuperFlagImpl(flag)
 	if err != nil {
-		glog.Fatal(err)
+		log.Fatal(err)
 	}
 	return sf
 }
@@ -136,7 +136,7 @@ func (sf *SuperFlag) String() string {
 func (sf *SuperFlag) MergeAndCheckDefault(flag string) *SuperFlag {
 	sf, err := sf.MergeWithDefault(flag)
 	if err != nil {
-		glog.Fatal(err)
+		log.Fatal(err)
 	}
 	return sf
 }
@@ -207,7 +207,7 @@ func (sf *SuperFlag) GetBool(opt string) bool {
 		err = errors.Wrapf(err,
 			"Unable to parse %s as bool for key: %s. Options: %s\n",
 			val, opt, sf)
-		glog.Fatalf("%+v", err)
+		log.Fatal(err.Error())
 	}
 	return b
 }
@@ -222,7 +222,7 @@ func (sf *SuperFlag) GetFloat64(opt string) float64 {
 		err = errors.Wrapf(err,
 			"Unable to parse %s as float64 for key: %s. Options: %s\n",
 			val, opt, sf)
-		glog.Fatalf("%+v", err)
+		log.Fatal(err.Error())
 	}
 	return f
 }
@@ -237,7 +237,7 @@ func (sf *SuperFlag) GetInt64(opt string) int64 {
 		err = errors.Wrapf(err,
 			"Unable to parse %s as int64 for key: %s. Options: %s\n",
 			val, opt, sf)
-		glog.Fatalf("%+v", err)
+		log.Fatal(err.Error())
 	}
 	return i
 }
@@ -252,7 +252,7 @@ func (sf *SuperFlag) GetUint64(opt string) uint64 {
 		err = errors.Wrapf(err,
 			"Unable to parse %s as uint64 for key: %s. Options: %s\n",
 			val, opt, sf)
-		glog.Fatalf("%+v", err)
+		log.Fatal(err.Error())
 	}
 	return u
 }
@@ -267,7 +267,7 @@ func (sf *SuperFlag) GetUint32(opt string) uint32 {
 		err = errors.Wrapf(err,
 			"Unable to parse %s as uint32 for key: %s. Options: %s\n",
 			val, opt, sf)
-		glog.Fatalf("%+v", err)
+		log.Fatalf("%+v", err)
 	}
 	return uint32(u)
 }
@@ -283,7 +283,7 @@ func (sf *SuperFlag) GetPath(opt string) string {
 	p := sf.GetString(opt)
 	path, err := expandPath(p)
 	if err != nil {
-		glog.Fatalf("Failed to get path: %+v", err)
+		log.Fatalf("Failed to get path: %+v", err)
 	}
 	return path
 }


### PR DESCRIPTION
Removes glog dependency as proposed in:

- https://github.com/dgraph-io/ristretto/pull/293
- https://github.com/dgraph-io/ristretto/pull/292

## Background

glog adds global flags so it is not a good library (adding to an existing program causes a panic if a flag name conflicts).

Also some changes was applied according to golangci-lint issues.